### PR TITLE
Upgrade LINKIS_VERSION to 1.8.0 to Fix Integration Test Failure in GitHub Actions

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -45,7 +45,7 @@ jobs:
       TAG: ${{ github.sha }}
       SKIP_TEST: true
       HUB: ghcr.io/apache/linkis
-      LINKIS_VERSION: 1.7.0
+      LINKIS_VERSION: 1.8.0
     steps:
       - name: Free up disk space
         run: |

--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -33,8 +33,8 @@ jobs:
     env:
       TAG: ${{ github.sha }}
       SKIP_TEST: true
-      HUB: ghcr.io/apache/linkis
-      LINKIS_VERSION: 1.7.0
+      HUB: ghcr.io/${{ github.repository }}
+      LINKIS_VERSION: 1.8.0
     steps:
     - name: Checkout
       uses: actions/checkout@v4


### PR DESCRIPTION
Merge from upstream.